### PR TITLE
tar step was failing without - flag

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,7 +27,7 @@ gulp.task('download-ffmpeg', function(cb) {
 });
 
 gulp.task('untar-ffmpeg', shell.task([
-	'tar xvf ' + filename + ' -C ./build'
+	'tar -xvf ' + filename + ' -C ./build'
 ]));
 
 // This is still buggy


### PR DESCRIPTION
Hi @binoculars!  Thanks so much for creating this great example lambda application.  I'm staring to explore this route a bit to run ffmpeg in a contained lambda service and was using your application as a great starting point.  

I noticed for me the tar step wasn't properly running and including ffmpeg in the package.  Not sure if you've needed this as well, but I thought I'd push this upstream :)
