### PR TITLE
ffmpeg exit code is not checked

### DIFF
--- a/platform/common.js
+++ b/platform/common.js
@@ -129,7 +129,13 @@ function ffmpeg(keyPrefix) {
 		spawn('ffmpeg', args, opts)
 			.on('message', msg => log(msg))
 			.on('error', reject)
-			.on('close', resolve);
+			.on('close', (code, signal) => {
+                if (code === 0) {
+                    resolve();
+                } else {
+                    reject(new Error(`bad ffmpeg exit code: ${code}`));
+                }
+            });
 	});
 }
 


### PR DESCRIPTION
Hi

ffmpeg exit code is not analyzed and it leads to blank files uploaded to the target project in case of errors.
I hit this problem in an internal project where ffmpeg arguments are configurable and can be supplied by the user. 

The reason is that `on('error')` doesn't seem to catch bad exit code and only handles cases when ffmpeg can't be launched at all.

Here's the demo:
```
import {spawn} from 'child_process';

spawn('/bin/ls', ['/badfolder'])
    .on('error', (error) => {
        console.error(`error: ${error}`);
    })
    .on('close', (code, signal) => {
        console.log(`exit code: ${code}`);
    });

```
Here's the output:
```
babel-node test-spawn.js 
exit code: 2
```
That is the error callback is not called.
To fix it we just need to analyze the exit code which is non-zero in case of ffmpeg failures