### PR TITLE
bump node to 8.10 for AWS since they do not support 6.10 any longer

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -167,7 +167,7 @@ fs.readdirSync(baseDir)
 								node: (() => {
 									switch(platform) {
 										case 'aws':
-											return '6.10';
+											return '8.10';
 										case 'gcp':
 											return '6.11';
 										default:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "AWS Lambda function to resize video and generate a thumbnail",
   "engines": {
-    "node": ">=6.10",
+    "node": ">=8.10",
     "npm": ">=3"
   },
   "main": "index.js",

--- a/platform/aws/cloudformation.json
+++ b/platform/aws/cloudformation.json
@@ -210,7 +210,7 @@
 				},
 				"Timeout": 30,
 				"Handler": "aws/index.handler",
-				"Runtime": "nodejs6.10",
+				"Runtime": "nodejs8.10",
 				"MemorySize": 1536
 			}
 		},


### PR DESCRIPTION
Hi,

I could no longer deploy aws-ffmpeg-lambda to AWS because Lambda complained about using node 6.10, so I bumped the version.

* Unit tests passed locally
* Explanations for integration tests in README were not sufficient for me to run them locally, could someone check this or tell me what to do here exactly? I'll put it in the README then as well.
* Works on AWS
* No idea whether it should be bumped for Google cloud as well, looks like we should change it to 8.15.0 there?

Best regards!